### PR TITLE
Add imports for Heading and Image classes

### DIFF
--- a/src/Nova/Page.php
+++ b/src/Nova/Page.php
@@ -3,6 +3,8 @@
 namespace OptimistDigital\NovaPageManager\Nova;
 
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Image;
+use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Panel;


### PR DESCRIPTION
Heading and Image classes were not imported therefore an error was thrown when using SEO.