### PR TITLE
Page-Manager Bug Checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,20 +155,6 @@ public function boot()
 }
 ```
 
-### Add links to front-end pages
-
-To display a link next to the slug that links to the actual page in the front-end you must pass a function that generates the URL to `NovaPageManager::pagePreviewUrl()`.
-
-As shown in this example:
-
-```php
-use \OptimistDigital\NovaPageManager\NovaPageManager;
-
-NovaPageManager::pagePreviewUrl(function (Page $page) {
-  return env('FRONTEND_URL') . $page->path;
-});
-```
-
 ### Overwrite package resources
 
 You can overwrite the package resources (Page & Region) by setting the config options in `nova-page-manager.php`.

--- a/config/nova-page-manager.php
+++ b/config/nova-page-manager.php
@@ -1,5 +1,7 @@
 <?php
 
+use OptimistDigital\NovaPageManager\Models\Page;
+
 return [
 
   /*
@@ -47,6 +49,20 @@ return [
   | Add a custom implementation of the Region resource
   |
   */
-  'region_resource' => null
+  'region_resource' => null,
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Preview url
+    |--------------------------------------------------------------------------
+    |
+    | Sets page preview url
+    |
+    */
+    'page_url' => function(Page $page) {
+        $previewLink = $page->preview_token !== null ? '?preview=' . $page->preview_token : '';
+        return rtrim(config('app.url'), '/') . $page->path . $previewLink;
+    }
 
 ];

--- a/config/nova-page-manager.php
+++ b/config/nova-page-manager.php
@@ -52,17 +52,17 @@ return [
   'region_resource' => null,
 
 
-    /*
-    |--------------------------------------------------------------------------
-    | Preview url
-    |--------------------------------------------------------------------------
-    |
-    | Sets page preview url
-    |
-    */
-    'page_url' => function(Page $page) {
-        $previewLink = $page->preview_token !== null ? '?preview=' . $page->preview_token : '';
-        return rtrim(config('app.url'), '/') . $page->path . $previewLink;
-    }
+  /*
+  |--------------------------------------------------------------------------
+  | Preview url
+  |--------------------------------------------------------------------------
+  |
+  | Sets page preview url
+  |
+  */
+  'page_url' => function(Page $page) {
+    $previewLink = $page->preview_token !== null ? '?preview=' . $page->preview_token : '';
+    return rtrim(config('app.url'), '/') . $page->path . $previewLink;
+  }
 
 ];

--- a/resources/draft-button/components/FormButton.vue
+++ b/resources/draft-button/components/FormButton.vue
@@ -32,13 +32,6 @@ export default {
     }
   },
 
-  beforeMount() {
-    if (this.field.childDraft && this.field.childDraft.id) {
-      this.$router.replace(`/resources/pages/${this.field.childDraft.id}/edit`);
-      this.$nextTick(this.$parent.$parent.getFields); // ! Might break with new Laravel Nova versions
-    }
-  },
-
   methods: {
     fill(formData) {
       if (this.draft) {

--- a/resources/published-field/components/IndexField.vue
+++ b/resources/published-field/components/IndexField.vue
@@ -11,7 +11,7 @@ export default {
 
   computed: {
     isPublished() {
-      return !!this.field.value || this.field.draftParent;
+      return !!this.field.value || !!this.field.draftParent;
     },
 
     isDraft() {

--- a/resources/published-field/components/IndexField.vue
+++ b/resources/published-field/components/IndexField.vue
@@ -11,7 +11,7 @@ export default {
 
   computed: {
     isPublished() {
-      return !!this.field.value;
+      return !!this.field.value || this.field.draftParent;
     },
 
     isDraft() {

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -16,6 +16,12 @@ class PageController extends Controller {
             if (isset($pageToPublish->draftParent)) {
                 $publishedPage = $pageToPublish->draftParent;
                 $publishedPage->data = $pageToPublish->data;
+                $publishedPage->name = $pageToPublish->name;
+                $publishedPage->slug = $pageToPublish->slug;
+                $publishedPage->seo_title = $pageToPublish->seo_title;
+                $publishedPage->parent_id = $pageToPublish->parent_id;
+                $publishedPage->seo_description = $pageToPublish->seo_description;
+                $publishedPage->seo_image = $pageToPublish->seo_image;
                 $publishedPage->published = true;
                 $publishedPage->save();
                 $pageToPublish->delete();

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -76,6 +76,11 @@ class Page extends TemplateModel
         return $this->hasOne(Page::class, 'draft_parent_id', 'id');
     }
 
+    public function isDraft()
+    {
+        return isset($this->preview_token) ? true : false;
+    }
+
     public function getPathAttribute()
     {
         if (!isset($this->parent)) return $this->normalizePath($this->slug);

--- a/src/Nova/Page.php
+++ b/src/Nova/Page.php
@@ -106,6 +106,6 @@ HTML;
 
     public static function indexQuery(NovaRequest $request, $query)
     {
-        return $query->whereNull('draft_parent_id');
+        return $query->doesnthave('childDraft');
     }
 }

--- a/src/Nova/Page.php
+++ b/src/Nova/Page.php
@@ -40,7 +40,7 @@ class Page extends TemplateResource
             ID::make()->sortable(),
             Text::make('Name', 'name')->rules('required'),
             Text::make('Slug', 'slug')
-                ->creationRules('required', "unique:{$tableName},slug,NULL,id,locale,$request-locale")
+                ->creationRules('required', "unique:{$tableName},slug,NULL,id,locale,$request->locale")
                 ->updateRules('required', "unique:{$tableName},slug,{{resourceId}},id,published,{{published}},locale,$request->locale")
                 ->onlyOnForms(),
             Text::make('Slug', function () use ($path, $pageUrl) {

--- a/src/NovaPageManager.php
+++ b/src/NovaPageManager.php
@@ -4,13 +4,13 @@ namespace OptimistDigital\NovaPageManager;
 
 use Laravel\Nova\Nova;
 use Laravel\Nova\Tool;
+use OptimistDigital\NovaPageManager\Models\Page;
 
 class NovaPageManager extends Tool
 {
     private static $templates = [];
     private static $locales = [];
     private static $draftEnabled = false;
-    private static $getPageFrontendUrlFn;
 
     /**
      * Perform any tasks that need to happen when the tool is booted.
@@ -80,14 +80,13 @@ class NovaPageManager extends Tool
         return config('nova-page-manager.table', 'nova_page_manager') . '_regions';
     }
 
-    public static function pagePreviewUrl(\Closure $fn)
+    public static function getPageUrl(Page $page)
     {
-        self::$getPageFrontendUrlFn = $fn;
-    }
-
-    public static function getPagePreviewUrlFn()
-    {
-        return self::$getPageFrontendUrlFn;
+        $getPageUrl = config('nova-page-manager.page_url');
+        if ($getPageUrl) {
+            return $getPageUrl($page);
+        }
+        return null;
     }
 
     public static function draftEnabled(): bool


### PR DESCRIPTION
- [x] Preview link modifications
- [x] Bug when publishing a draft to an existing page
- [x] Not redirecting when trying to edit a draft
- [x] Update readme according to changes


> 1. Preview link modifications

Shows either _View Draft_ or _View_, depending on if the item is a draft or not.
Getting preview link is done in config file

> 2. Bug when publishing a draft to an existing page

When publishing a draft, now updates all the fields in parent. Previously only saved the data and published field 

> 3. Not redirecting when trying to edit a draft

Previously, when trying to edit a draft, it wouldn't redirect to the correct url, instead it would only change the url. 


> 4. Update readme according to changes

Preview link is available without defining it in the NovaServiceProvider
