### PR TITLE
fix: name indexes

### DIFF
--- a/database/migrations/2019_03_13_000000_create_page_manager_tables.php
+++ b/database/migrations/2019_03_13_000000_create_page_manager_tables.php
@@ -20,7 +20,7 @@ class CreatePageManagerTables extends Migration
             $table->timestamps();
             $table->enum('type', ['page', 'region']);
             $table->string('name');
-            $table->string('slug')->default('')->unique();
+            $table->string('slug')->default('')->unique('nova_page_manager_slug_unique');
             $table->string('locale');
             $table->string('template');
             $table->string('seo_title')->nullable();
@@ -29,7 +29,7 @@ class CreatePageManagerTables extends Migration
             $table->bigInteger('parent_id')->nullable();
             $table->json('data')->nullable();
 
-            $table->unique(['parent_id', 'locale']);
+            $table->unique(['parent_id', 'locale'], 'nova_page_manager_parent_id_locale_unique');
         });
     }
 

--- a/database/migrations/2019_04_18_000001_add_child_parent_relationships.php
+++ b/database/migrations/2019_04_18_000001_add_child_parent_relationships.php
@@ -36,7 +36,7 @@ class AddChildParentRelationships extends Migration
         });
 
         Schema::table($tableName, function (Blueprint $table) use ($tableName) {
-            $table->dropUnique(['parent_id', 'locale']);
+            $table->dropUnique('nova_page_manager_parent_id_locale_unique');
 
             // Rename "parent_id" to "locale_parent_id"
             $table->renameColumn('parent_id', 'locale_parent_id');
@@ -52,7 +52,7 @@ class AddChildParentRelationships extends Migration
             $table->foreign('parent_id')->references('id')->on($tableName);
 
             // Force "locale_parent_id <-> locale" pair to be unique
-            $table->unique(['locale_parent_id', 'locale']);
+            $table->unique(['locale_parent_id', 'locale'], 'nova_page_manager_locale_parent_id_locale_unique');
         });
     }
 

--- a/database/migrations/2019_04_24_000002_create_region_and_pages_tables.php
+++ b/database/migrations/2019_04_24_000002_create_region_and_pages_tables.php
@@ -28,7 +28,7 @@ class CreateRegionAndPagesTables extends Migration
             $table->bigInteger('locale_parent_id')->nullable();
             $table->json('data')->nullable();
 
-            $table->unique(['locale', 'template']);
+            $table->unique(['locale', 'template'], 'nova_page_manager_locale_template');
         });
 
         // Move all regions from original table to new regions table

--- a/database/migrations/2019_05_03_000003_make_slug_locale_pair_unique.php
+++ b/database/migrations/2019_05_03_000003_make_slug_locale_pair_unique.php
@@ -13,11 +13,11 @@ class MakeSlugLocalePairUnique extends Migration
     public function up()
     {
         $tableName = config('nova-page-manager.table', 'nova_page_manager');
-        $pagesTableName = $tableName . '_pages';
+        $pagesTableName = $tableName.'_pages';
 
         Schema::table($pagesTableName, function ($table) {
             $table->dropUnique('nova_page_manager_slug_unique');
-            $table->unique(['locale', 'slug']);
+            $table->unique(['locale', 'slug'], 'nova_page_manager_locale_slug_unique');
         });
     }
 
@@ -29,11 +29,11 @@ class MakeSlugLocalePairUnique extends Migration
     public function down()
     {
         $tableName = config('nova-page-manager.table', 'nova_page_manager');
-        $pagesTableName = $tableName . '_pages';
+        $pagesTableName = $tableName.'_pages';
 
         Schema::table($pagesTableName, function ($table) {
-            $table->dropUnique(['locale', 'slug']);
-            $table->unique('slug');
+            $table->dropUnique(['locale', 'slug'], 'nova_page_manager_locale_slug_unique');
+            $table->unique('slug', 'nova_page_manager_slug_unique');
         });
     }
 }

--- a/database/migrations/2019_06_10_000004_add_draft_fields_to_page.php
+++ b/database/migrations/2019_06_10_000004_add_draft_fields_to_page.php
@@ -20,12 +20,12 @@ class AddDraftFieldsToPage extends Migration
             $table->boolean('published')->default(true);
             $table->bigInteger('draft_parent_id')->nullable()->unsigned();
             $table->foreign('draft_parent_id')->references('id')->on($pagesTableName)->onDelete('cascade');
-            $table->dropUnique(['locale', 'slug']);
-            $table->unique(['locale', 'slug', 'published']);
+            $table->dropUnique('nova_page_manager_locale_slug_unique');
+            $table->unique(['locale', 'slug', 'published'], 'nova_page_manager_locale_slug_published_unique');
 
-            $table->index('locale_parent_id');
+            $table->index('locale_parent_id', 'nova_page_manager_pages_locale_parent_id_index');
             $table->dropUnique('nova_page_manager_locale_parent_id_locale_unique');
-            $table->unique(['locale_parent_id', 'locale', 'published']);
+            $table->unique(['locale_parent_id', 'locale', 'published'], 'nova_page_manager_locale_parent_id_locale_published_unique');
             $table->dropIndex('nova_page_manager_pages_locale_parent_id_index');
         });
 
@@ -41,16 +41,16 @@ class AddDraftFieldsToPage extends Migration
         $pagesTableName = NovaPageManager::getPagesTableName();
 
         Schema::table($pagesTableName, function ($table) use ($pagesTableName) {
-            $table->dropForeign($pagesTableName . '_draft_parent_id_foreign');
+            $table->dropForeign($pagesTableName.'_draft_parent_id_foreign');
             $table->dropColumn('draft_parent_id');
             $table->dropColumn('published');
             $table->dropColumn('preview_token');
-            $table->dropUnique(['locale', 'slug', 'published']);
-            $table->unique(['locale', 'slug']);
+            $table->dropUnique('nova_page_manager_locale_slug_published_unique');
+            $table->unique(['locale', 'slug'], 'nova_page_manager_locale_slug_unique');
 
-            $table->index('locale_parent_id');
-            $table->dropUnique(['locale_parent_id', 'locale', 'published']);
-            $table->unique(['locale_parent_id', 'locale']);
+            $table->index('locale_parent_id', 'nova_page_manager_pages_locale_parent_id_index');
+            $table->dropUnique('nova_page_manager_locale_slug_published_unique');
+            $table->unique(['locale_parent_id', 'locale'], 'nova_page_manager_locale_parent_id_locale_published_unique');
             $table->dropIndex('nova_page_manager_pages_locale_parent_id_index');
         });
     }


### PR DESCRIPTION
The migrations break for people that use a custom table name.  I've named the indexes to make sure the index drops still work with different table names. 