### PR TITLE
Add a view variable in pageDate

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -114,6 +114,7 @@ if (!function_exists('nova_format_page')) {
             'path' => $page->path ?: null,
             'data' => nova_resolve_template_model_data($page),
             'template' => $page->template ?: null,
+            'view' => $template::$view ?: null,
         ];
 
         if ($template::$seo) {


### PR DESCRIPTION
Add a view variable to pageDate. This way you can use more then one template with the same view. Inside the template you can set a public static $view = ''; that you can use inside your routes if you use nova_get_page_by_slug for example.