### PR TITLE
Respect table name config

### DIFF
--- a/database/migrations/2019_11_29_000005_make_slug_locale_published_parent_id_pair_unique.php
+++ b/database/migrations/2019_11_29_000005_make_slug_locale_published_parent_id_pair_unique.php
@@ -16,10 +16,10 @@ class MakeSlugLocalePublishedParentidPairUnique extends Migration
     {
         $pagesTableName = NovaPageManager::getPagesTableName();
         $key = DB::select(
-            DB::raw('SHOW KEYS
-            FROM nova_page_manager_pages
-            WHERE Key_name LIKE "nova_page_manager_pages%"
-            AND Key_name LIKE "%locale_slug_published_unique"')
+            DB::raw("SHOW KEYS
+            FROM $pagesTableName
+            WHERE Key_name LIKE 'nova_page_manager_pages%'
+            AND Key_name LIKE '%locale_slug_published_unique'")
         );
         $indexValue = empty($key) ? 'nova_page_manager' : 'nova_page_manager_pages';
 


### PR DESCRIPTION
Fixes error when migrating with custom table name.
```
Migrating: 2019_11_29_000005_make_slug_locale_published_parent_id_pair_unique
Illuminate\Database\QueryException
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'app.nova_page_manager_pages' doesn't exist (SQL: SHOW KEYS FROM nova_page_manager_pages WHERE Key_name LIKE "nova_page_manager_pages%"
```