### PR TITLE
split a migration operation into two separate chunks for sqlite support

### DIFF
--- a/database/migrations/2019_04_18_000001_add_child_parent_relationships.php
+++ b/database/migrations/2019_04_18_000001_add_child_parent_relationships.php
@@ -37,7 +37,9 @@ class AddChildParentRelationships extends Migration
 
         Schema::table($tableName, function (Blueprint $table) use ($tableName) {
             $table->dropUnique('nova_page_manager_parent_id_locale_unique');
+        });
 
+        Schema::table($tableName, function (Blueprint $table) use ($tableName) {
             // Rename "parent_id" to "locale_parent_id"
             $table->renameColumn('parent_id', 'locale_parent_id');
         });


### PR DESCRIPTION
Fix Sqlite error

```
Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 no such index: nova_page_manager_parent_id_locale_unique (SQL: DROP INDEX nova_page_manager_parent_id_locale_unique)
```