### PR TITLE
Add translit panel name

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -347,6 +347,7 @@ if (!function_exists('nova_resolve_fields_data')) {
 if (!function_exists('nova_page_manager_sanitize_panel_name')) {
     function nova_page_manager_sanitize_panel_name($name)
     {
+        $name = \Illuminate\Support\Str::slug($name);
         $removedSpecialChars = preg_replace("/[^A-Za-z0-9 ]/", '', $name);
         $snakeCase = preg_replace("/\s+/", '_', $removedSpecialChars);
         return strtolower($snakeCase);


### PR DESCRIPTION
Added transliteration of the panel name, because if you specify a name in another language, for example Russian, in the database I just get "_".