### PR TITLE
Return a null instead of an exception

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -387,7 +387,8 @@ if (!function_exists('nova_page_manager_get_page_by_path')) {
                 });
 
             if (isset($locale)) $query->where('locale', $locale);
-            $page = $query->firstOrFail();
+            $page = $query->first();
+            if (empty($page)) return null;
             $parent = $page;
         }
 


### PR DESCRIPTION
Forgot in one more place to replace the firstOrFail() method on the first()

The same method is nova_page_manager_get_page_by_path. In all cases, null is returned, and here an exception is thrown.
[https://github.com/optimistdigital/nova-page-manager/blob/1f8cec6783298d01457e6d62d7bd6bc9e55c8081/src/helpers.php#L390](url)


#83 