### PR TITLE
Nova 3 style Panel behaviour with override option

### DIFF
--- a/src/Nova/Fields/PageManagerField.php
+++ b/src/Nova/Fields/PageManagerField.php
@@ -113,8 +113,12 @@ class PageManagerField extends Field
 
         $attribute = $field->meta['originalAttribute'];
 
-        if (isset($field->assignedPanel->meta['fieldPrefix'])) {
-            $fieldPrefix = $field->assignedPanel->meta['fieldPrefix'];
+        if (isset($field->assignedPanel)) {
+            if(isset($field->assignedPanel->meta['fieldPrefix'])) {
+                $fieldPrefix = $field->assignedPanel->meta['fieldPrefix'];
+            } else {
+                $fieldPrefix = Str::slug($field->assignedPanel->name, '_');
+            }
             $attribute = $fieldPrefix . '->' . $attribute;
         }
 


### PR DESCRIPTION
Revert to the Nova 3 style behaviour of storing/retrieving Panel data, using sanitized `Str::slug('_')` versions of the Panel name by default, but still allow for setting a `fieldPrefix` override if needed

Fixes https://github.com/outl1ne/nova-page-manager/issues/134