### PR TITLE
make stubs return empty array if no data

### DIFF
--- a/src/Stubs/PageTemplate.php
+++ b/src/Stubs/PageTemplate.php
@@ -23,7 +23,7 @@ class :className extends Template
     public function resolve($page, $params): array
     {
         // Modify data as you please (ie turn ID-s into models)
-        return $page->data;
+        return $page->data ?? [];
     }
 
     // Optional suffix to the route (ie {blogPostName})

--- a/src/Stubs/RegionTemplate.php
+++ b/src/Stubs/RegionTemplate.php
@@ -23,6 +23,6 @@ class :className extends Template
     public function resolve($region, $params): array
     {
         // Modify data as you please (ie turn ID-s into models)
-        return $region->data;
+        return $region->data ?? [];
     }
 }


### PR DESCRIPTION
Newly created pages/templates that have no data yet return null from $page->data, this fixes it

![image](https://user-images.githubusercontent.com/19284921/198273628-430156a1-5e5d-4c32-8fd9-ae21cb058926.png)
