### PR TITLE
fix error in page structure when no template found

### DIFF
--- a/src/Helpers/NPMHelpers.php
+++ b/src/Helpers/NPMHelpers.php
@@ -52,6 +52,7 @@ class NPMHelpers
             if (isset($keys)) {
                 $formattedPage = $page->only($keys);
                 $template = NPM::getPageTemplateBySlug($page->template);
+                if (empty($template)) return null;
                 $templateClass = new $template['class'];
 
                 if (in_array('slug', $keys)) $formattedPage['slug'] = $page->getTranslations('slug') ?: [];

--- a/src/Helpers/NPMHelpers.php
+++ b/src/Helpers/NPMHelpers.php
@@ -52,6 +52,7 @@ class NPMHelpers
             if (isset($keys)) {
                 $formattedPage = $page->only($keys);
                 $template = NPM::getPageTemplateBySlug($page->template);
+                
                 if (empty($template)) return null;
                 $templateClass = new $template['class'];
 


### PR DESCRIPTION
When there is a page in the pages table with a template that's not in config, building the structure will currently throw this error

`Trying to access array offset on value of type null {"exception":"[object] (ErrorException(code: 0): Trying to access array offset on value of type null at vendor/outl1ne/nova-page-manager/src/Helpers/NPMHelpers.php:55)`