### PR TITLE
Update nova-page-manager.php

### DIFF
--- a/config/nova-page-manager.php
+++ b/config/nova-page-manager.php
@@ -25,13 +25,13 @@ return [
     'templates' => [
         'pages' => [
             // 'home-page' => [
-            //     'class' => '\App\Nova\Templates\HomePageTemplate',
+            //     'class' => 'App\Nova\Templates\HomePageTemplate',
             //     'unique' => true, // Whether more than one page can be created with this template
             // ],
         ],
         'regions' => [
             // 'header' => [
-            //     'class' => '\App\Nova\Templates\HeaderRegionTemplate',
+            //     'class' => 'App\Nova\Templates\HeaderRegionTemplate',
             //     'unique' => true,
             // ],
         ],


### PR DESCRIPTION
SEO Fields are not showing because className on the Outl1ne\PageManager\Npm.php line 87 are not equal.