### PR TITLE
Fix error on page list view

### DIFF
--- a/src/Nova/Resources/Page.php
+++ b/src/Nova/Resources/Page.php
@@ -147,7 +147,7 @@ class Page extends TemplateResource
         if ($this->resource?->id) {
             $path = $this->path ?? [];
             $locales = NPM::getLocales();
-            $pathSuffix = $this->template->pathSuffix();
+            $pathSuffix = $this->template?->pathSuffix();
 
             foreach ($locales as $key => $localeName) {
                 // Explode path and remove page's own path + suffix if it has one


### PR DESCRIPTION
Fixes this error: `Call to a member function pathSuffix() on null`

It currently happens when loading pages list view if there's a page in the database that doesn't have a matching template. It might happen when a template gets renamed for example