### PR TITLE
fix casting of datetime fields

### DIFF
--- a/src/Http/Controllers/PageManagerController.php
+++ b/src/Http/Controllers/PageManagerController.php
@@ -48,7 +48,7 @@ class PageManagerController extends Controller
             $fields = $templateClass->fields($request);
 
             // Fix DateTime fields
-            collect($fields)->pluck('data')->flatten(1)->each(function ($field) use ($dataObject) {
+            collect($fields)->each(function ($field) use ($dataObject) {
                 if ($field instanceof \Laravel\Nova\Fields\DateTime) {
                     $dataObject->{$field->attribute} = Carbon::parse($dataObject->{$field->attribute} ?? null);
                 }

--- a/src/Http/Controllers/PageManagerController.php
+++ b/src/Http/Controllers/PageManagerController.php
@@ -50,7 +50,10 @@ class PageManagerController extends Controller
             // Fix DateTime fields
             collect($fields)->each(function ($field) use ($dataObject) {
                 if ($field instanceof \Laravel\Nova\Fields\DateTime) {
-                    $dataObject->{$field->attribute} = Carbon::parse($dataObject->{$field->attribute} ?? null);
+                    $currentValue = $dataObject->{$field->attribute} ?? null;
+                    if ($currentValue) {
+                        $dataObject->{$field->attribute} = Carbon::parse($currentValue);
+                    }
                 }
             });
 


### PR DESCRIPTION
The `->pluck('data')->flatten(1)` seems to be a typo because all the fields inside that `each()` are null