### PR TITLE
Call resolveForDisplay method on template fields

### DIFF
--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -1,5 +1,6 @@
 export default {
-  async getFields(type, resourceId) {
-    return Nova.request().get(`/nova-vendor/page-manager/${type}/${resourceId}/fields`);
+  async getFields(type, resourceId, view) {
+    const query = new URLSearchParams({view})
+    return Nova.request().get(`/nova-vendor/page-manager/${type}/${resourceId}/fields?${query.toString()}`);
   },
 };

--- a/resources/js/components/PageManagerField.vue
+++ b/resources/js/components/PageManagerField.vue
@@ -59,7 +59,7 @@ export default {
   methods: {
     async refreshFields() {
       this.loading = true;
-      const { data } = await API.getFields(this.field.type, this.resourceId);
+      const { data } = await API.getFields(this.field.type, this.resourceId, this.field.view);
       this.panelsWithFields = data.panelsWithFields;
       this.seoPanelsWithFields = data.seoPanelsWithFields;
       this.loading = false;

--- a/src/Http/Controllers/PageManagerController.php
+++ b/src/Http/Controllers/PageManagerController.php
@@ -75,6 +75,7 @@ class PageManagerController extends Controller
             $fieldCollection->each(fn ($field) => $field->template = $templateClass);
             $fieldCollection = $fieldCollection->map(fn ($field) => PageManagerField::transformFieldAttributes($field));
             $fieldCollection->resolve($dataObject);
+            $fieldCollection->resolveForDisplay($dataObject);
             $fieldCollection->assignDefaultPanel(__('novaPageManager.defaultPanelName'));
             $fieldsData[$key] = $fieldCollection;
 

--- a/src/Http/Controllers/PageManagerController.php
+++ b/src/Http/Controllers/PageManagerController.php
@@ -74,8 +74,12 @@ class PageManagerController extends Controller
 
             $fieldCollection->each(fn ($field) => $field->template = $templateClass);
             $fieldCollection = $fieldCollection->map(fn ($field) => PageManagerField::transformFieldAttributes($field));
+
             $fieldCollection->resolve($dataObject);
-            $fieldCollection->resolveForDisplay($dataObject);
+            if ($request->get('view') == 'detail') {
+                $fieldCollection->resolveForDisplay($dataObject);
+            }
+
             $fieldCollection->assignDefaultPanel(__('novaPageManager.defaultPanelName'));
             $fieldsData[$key] = $fieldCollection;
 


### PR DESCRIPTION
Currently calling `displayUsing` method on fields that are in templates have no effect. I added `resolveForDisplay` call to `PageManagerController getFields` without any checks but thats not ideal as edit view does not require this to be called.

There is also no way of knowing in `PageManagerController getFields` method which view you are currently on.
In Nova's native resource client request query (or body) usually contains that information (ex. https://d.pr/i/O5DZ2J) or by controller method that was invoked.

I added appropriate query param to `getFields` request to differentiate in what view called `getFields`
