### PR TITLE
Move `Nova::script()/Nova::style()` methods to NPMServiceProvider

### DIFF
--- a/src/NPMServiceProvider.php
+++ b/src/NPMServiceProvider.php
@@ -30,6 +30,9 @@ class NPMServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Nova::script('nova-page-manager', __DIR__ . '/../dist/js/entry.js');
+        Nova::style('nova-page-manager', __DIR__ . '/../dist/css/entry.css');
+        
         // Load all data
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
         $this->loadTranslations(__DIR__ . '/../lang', 'nova-page-manager');

--- a/src/PageManager.php
+++ b/src/PageManager.php
@@ -14,8 +14,7 @@ class PageManager extends Tool
 
     public function boot()
     {
-        Nova::script('nova-page-manager', __DIR__ . '/../dist/js/entry.js');
-        Nova::style('nova-page-manager', __DIR__ . '/../dist/css/entry.css');
+       //
     }
 
     public function menu(Request $request)


### PR DESCRIPTION
The correct place to attach the relevant JS/CSS files for a tool is in the ServiceProviders `boot()` method

Using the latest Nova, the tools CSS and JS files were not loading since they were being initialised in the wrong place.

This PR fixes issue [#166](https://github.com/outl1ne/nova-page-manager/issues/166)