### PR TITLE
Fix Laravel 12 compatibility - ConditionallyLoadsAttributes trait conflict

### DIFF
--- a/src/Http/Controllers/PageManagerController.php
+++ b/src/Http/Controllers/PageManagerController.php
@@ -11,12 +11,23 @@ use Illuminate\Routing\Controller;
 use Laravel\Nova\Fields\FieldCollection;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Outl1ne\PageManager\Nova\Fields\PageManagerField;
-use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
+use Illuminate\Http\Resources\MissingValue;
 use Illuminate\Support\Facades\Storage;
 
 class PageManagerController extends Controller
 {
-    use ResolvesFields, ConditionallyLoadsAttributes;
+    use ResolvesFields;
+
+    /**
+     * Filter the given data, removing any missing values.
+     *
+     * @param  array  $data
+     * @return array
+     */
+    protected function filter($data)
+    {
+        return collect($data)->filter(fn ($value) => ! $value instanceof MissingValue)->all();
+    }
 
     public function getFields(Request $request, $type, $resourceId, $isSyncRequest = false)
     {

--- a/src/Nova/Fields/PageManagerField.php
+++ b/src/Nova/Fields/PageManagerField.php
@@ -9,12 +9,10 @@ use Laravel\Nova\Fields\FieldCollection;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
+use Illuminate\Http\Resources\MissingValue;
 
 class PageManagerField extends Field
 {
-    use ConditionallyLoadsAttributes;
-
     public $component = 'page-manager-field';
     protected $template = null;
     protected $seoFields = null;
@@ -40,6 +38,17 @@ class PageManagerField extends Field
     {
         $this->seoFields = $seoFields;
         return $this;
+    }
+
+    /**
+     * Filter the given data, removing any missing values.
+     *
+     * @param  array  $data
+     * @return array
+     */
+    protected function filter($data)
+    {
+        return collect($data)->filter(fn ($value) => ! $value instanceof MissingValue)->all();
     }
 
     public function fill(NovaRequest $request, $model)


### PR DESCRIPTION
## Problem

Laravel 12 changed the visibility of the `when()` method in the 
`ConditionallyLoadsAttributes` trait from `public` to `protected`.

This causes a fatal error when using the package with Laravel 12:
```
Access level to Illuminate\Http\Resources\ConditionallyLoadsAttributes::when() 
must be public (as in class Laravel\Nova\Fields\Field)
```

## Solution

Remove the `ConditionallyLoadsAttributes` trait from `PageManagerField` and 
`PageManagerController`, and implement the `filter()` method directly since 
it's the only method being used from the trait.

## Changes

- `src/Nova/Fields/PageManagerField.php` - Remove trait, add `filter()` method
- `src/Http/Controllers/PageManagerController.php` - Remove trait, add `filter()` method

## Testing

Tested with:
- Laravel 12.43.1
- Nova 5.7.6
- PHP 8.x